### PR TITLE
Modified Tag of fortifydocker/dast-scanner to 23.2.ubi.8.6

### DIFF
--- a/charts/scancentral-dast/values.yaml
+++ b/charts/scancentral-dast/values.yaml
@@ -22,7 +22,8 @@ images:
     pullPolicy: "IfNotPresent"
   utilityservice:
     repository: fortifydocker/dast-scanner
-    tag: "23.2.ubi.8"
+    # tag: "23.2.ubi.8"
+    tag: "23.2.ubi.8.6"
     pullPolicy: "IfNotPresent"
   twofactorauth:
     repository: fortifydocker/fortify-2fa


### PR DESCRIPTION
Modified Tag of fortifydocker/dast-scanner to 23.2.ubi.8.6 because it fails on AutoScale as the AutoScale script tries to pull fortifydocker/dast-scanner:23.2.ubi.8.6. The Tag value seems to be hardcoded and it is not reading from values.yaml. Also dast-scanner is protected image in the values.yaml there is no way to supply credentials at the time of AutoScale.